### PR TITLE
Rename the container image to `ansible/creator-ee`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ansible DevTools Execution Environment
+# Ansible Creator Execution Environment
 
 This is a container (execution environment) aimed towards being used
 for development and testing of the Ansible content. We should also mention

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ passenv =
   {docker,check-diff}: DOCKER_BUILDKIT
 setenv =
   {docker,check-diff}: ANSIBLE_BUILDER_POST_ARGS = --container-runtime=docker
-  ANSIBLE_BUILDER_TARGET_CONTAINER_NAME = {env:ANSIBLE_BUILDER_TARGET_CONTAINER_NAME:quay.io/ansible/devtools-ee}
+  ANSIBLE_BUILDER_TARGET_CONTAINER_NAME = {env:ANSIBLE_BUILDER_TARGET_CONTAINER_NAME:quay.io/ansible/creator-ee}
   ANSIBLE_BUILDER_TARGET_CONTAINER_TAG = {env:ANSIBLE_BUILDER_TARGET_CONTAINER_TAG:latest}
 
 


### PR DESCRIPTION
We've made a change renaming this image once today but it seems there's a desire to do it again. To avoid miscommunication, I've written down some action items to make this happen. They should be done in the order they are listed.

Action item for  @ssbarnea:
* [x] Give the publishing bot account access to `ansible/creator-ee` *before merging this PR*

Everyone else:
* [ ] Have at least 2-3 approvals from the team
* [x] Rename this repo to `creator-ee`
* [ ] Merge the PR
* [ ] To test the publishing workflow, cut a new release by entering `v0.2.0a1` at https://github.com/ansible/devtools-ee/releases/new, waiting for the approval in the GHA workflow and confirming it