### PR TITLE
Ensure we use only released ansible-builder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-git+https://github.com/ansible/ansible-builder.git@devel#egg=ansible-builder

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ commands =
     -c . \
     {posargs:-t {env:ANSIBLE_BUILDER_TARGET_CONTAINER_NAME}:{env:ANSIBLE_BUILDER_TARGET_CONTAINER_TAG}} \
     {env:ANSIBLE_BUILDER_POST_ARGS:}
-deps = -r{toxinidir}/requirements.txt
+deps =
+  ansible-builder
 passenv =
   ANSIBLE_BUILDER_TARGET_CONTAINER_NAME
   ANSIBLE_BUILDER_TARGET_CONTAINER_TAG


### PR DESCRIPTION
As ansible-builder become stable we do not want to use unreleased
versions.

This change also prepares for refactoring dependency building and
future adoption of pip-tools/requirements.txt/constraints.txt, like
we already had on toolset project.
