### PR TITLE
chore: fix use of check-diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
         toxenv:
         - lint
         - deps
-        - podman
-        - docker
+        - podman,check-diff
+        - docker,check-diff
 
     env:
-      TOXENV: ${{ matrix.toxenv }},check-diff
+      TOXENV: ${{ matrix.toxenv }}
 
     steps:
     - name: Grab the source from Git

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ minversion = 3.18.0
 skipsdist = True
 envlist =
   lint
+  podman
   check-diff
 
 [testenv]
@@ -28,7 +29,7 @@ passenv =
   DOCKER_*
   SSH_AUTH_SOCK
 setenv =
-  {docker,check-diff}: ANSIBLE_BUILDER_POST_ARGS = --container-runtime=docker
+  {docker}: ANSIBLE_BUILDER_POST_ARGS = --container-runtime=docker
   ANSIBLE_BUILDER_TARGET_CONTAINER_NAME = {env:ANSIBLE_BUILDER_TARGET_CONTAINER_NAME:quay.io/ansible/creator-ee}
   ANSIBLE_BUILDER_TARGET_CONTAINER_TAG = {env:ANSIBLE_BUILDER_TARGET_CONTAINER_TAG:latest}
 
@@ -40,11 +41,11 @@ description =
 
 
 [testenv:check-diff]
+commands_pre =
 commands =
-  {[testenv]commands}
   {toxinidir}/tools/check_ansible_builder_changed.sh
 description =
-  Verify that the ansible-builder context is up-to-date
+  Verify that git status is not dirty
 
 [testenv:lint]
 description = Run all linters


### PR DESCRIPTION
Fix bug where running podman would have also involved
building container with docker first, doubling the runtime.

`check-diff` should not have imported commands from
root tox env as it would mean that chaining tox envs would
trigger multiple executions.

Also running check-diff on lint and deps was not desired.
