### PR TITLE
Add docker molecule driver

### DIFF
--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -4,7 +4,7 @@ ansible-core>=2.12
 ansible-lint>=5.3.1
 distro  # indirect
 molecule>=3.5.2
-molecule-docker>=1.0.1
+molecule-docker==1.1.0
 molecule-podman==1.1.0
 selinux  # indirect
 yamllint>=1.26.3

--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -4,5 +4,6 @@ ansible-core>=2.12
 ansible-lint>=5.3.1
 distro  # indirect
 molecule>=3.5.2
+molecule-docker>=1.0.1
 selinux  # indirect
 yamllint>=1.26.3

--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -5,6 +5,7 @@ collections:
   - name: ansible.windows
   - name: awx.awx
   - name: azure.azcollection
+  - name: community.docker
   - name: community.vmware
   - name: google.cloud
   - name: kubernetes.core


### PR DESCRIPTION
As this image is superseding the ansible toolset image, it should aim at feature parity with its precursor.

This change adds the molecule docker driver, and its necessary dependencies. This also includes the `community.docker` ansible collection, as written in the [molecule-docker README](https://github.com/ansible-community/molecule-docker/blob/main/README.rst).

Partly fixes: #20 