### PR TITLE
Add molecule-podman driver

### DIFF
--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -4,5 +4,6 @@ ansible-core>=2.12
 ansible-lint>=5.3.1
 distro  # indirect
 molecule>=3.5.2
+molecule-podman==1.1.0
 selinux  # indirect
 yamllint>=1.26.3

--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -6,6 +6,7 @@ collections:
   - name: awx.awx
   - name: azure.azcollection
   - name: community.vmware
+  - name: containers.podman
   - name: google.cloud
   - name: kubernetes.core
   - name: openstack.cloud


### PR DESCRIPTION
As this image is superseding the ansible toolset image, it should aim at feature parity with its precursor.

This change adds the molecule podman driver, and its necessary dependencies. This also includes the `containers.podman` ansible collection, as written in the molecule-podman README.

Partly fixes: ansible#20