### PR TITLE
Add molecule-containers driver

### DIFF
--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -4,8 +4,8 @@ ansible-core>=2.12
 ansible-lint>=5.3.1
 distro  # indirect
 molecule>=3.5.2
-molecule-containers>=1.0.2
-molecule-docker>=1.1.0
-molecule-podman>=1.1.0
+molecule-containers==1.0.2
+molecule-docker==1.1.0
+molecule-podman==1.1.0
 selinux  # indirect
 yamllint>=1.26.3

--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -4,7 +4,8 @@ ansible-core>=2.12
 ansible-lint>=5.3.1
 distro  # indirect
 molecule>=3.5.2
-molecule-docker==1.1.0
-molecule-podman==1.1.0
+molecule-containers>=1.0.2
+molecule-docker>=1.1.0
+molecule-podman>=1.1.0
 selinux  # indirect
 yamllint>=1.26.3


### PR DESCRIPTION
As this image is superseding the ansible toolset image, it should aim at feature parity with its precursor.

This change adds the molecule containers driver - which is a drop-in replacement for the existing Docker and Podman drivers - and its necessary dependencies. This also includes the community.docker and `containers.podman` ansible collections, as written in the `molecule-docker` and `molecule-podman` README.

This partly fixes: ansible#20

This should be merged only if #22 and #23 are successfully merged.