### PR TITLE
Add molecule-openstack driver

### DIFF
--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -4,7 +4,8 @@ ansible-core>=2.12
 ansible-lint>=5.3.1
 distro  # indirect
 molecule>=3.5.2
-molecule-docker==1.1.0
-molecule-podman==1.1.0
+molecule-docker>=1.1.0
+molecule-podman>=1.1.0
+molecule-openstack>=0.3
 selinux  # indirect
 yamllint>=1.26.3

--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -4,8 +4,8 @@ ansible-core>=2.12
 ansible-lint>=5.3.1
 distro  # indirect
 molecule>=3.5.2
-molecule-docker>=1.1.0
-molecule-podman>=1.1.0
-molecule-openstack>=0.3
+molecule-docker==1.1.0
+molecule-openstack==0.3
+molecule-podman==1.1.0
 selinux  # indirect
 yamllint>=1.26.3


### PR DESCRIPTION
As this image is superseding the ansible toolset image, it should aim at feature parity with its precursor.

This change adds the molecule openstack driver, and its necessary dependencies.

See: https://github.com/ansible/creator-ee/issues/20
