### PR TITLE
Fix release pipeline to trigger on published event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   release:
     types:
-      - created
+      - published
 
 permissions: {}
 


### PR DESCRIPTION
As yesterday release attempt failed to trigger the pipeline we
correct the trigger event. Based on configuration known to be working
from other devtools projects like ansible-lint and molecule.
