### PR TITLE
Add podman and docker binaries

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -28,3 +28,13 @@ COPY --from=galaxy /usr/share/ansible /usr/share/ansible
 COPY --from=builder /output/ /output/
 RUN /output/install-from-bindep && rm -rf /output/wheels
 RUN alternatives --set python /usr/bin/python3
+RUN dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+RUN dnf config-manager --set-disabled docker-ce-stable
+RUN rpm --install --nodeps --replacefiles --excludepath=/usr/bin/runc https://download.docker.com/linux/centos/8/x86_64/stable/Packages/containerd.io-1.5.10-3.1.el8.x86_64.rpm
+RUN dnf --assumeyes --enablerepo=docker-ce-stable install docker-ce
+RUN molecule --version
+RUN molecule drivers
+RUN ansible-lint --version
+RUN docker --version
+RUN podman --version
+RUN git --version

--- a/_build/bindep.txt
+++ b/_build/bindep.txt
@@ -1,1 +1,2 @@
 python38-devel [platform:rpm compile]
+podman [platform:rpm]

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -8,3 +8,16 @@ dependencies:
 additional_build_steps:
   append:
     - RUN alternatives --set python /usr/bin/python3
+    - RUN dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    - RUN dnf config-manager --set-disabled docker-ce-stable
+    #  This is a workaround due to a conflict between the packaged version of runc in the containerd.io package from Docker and the CentOS 8 Stream native
+    #  version packaged for Podman and Skopeo. This can be changed once https://github.com/docker/containerd-packaging/pull/231 is merged and available
+    #  upstream via the Docker repository. Cudos for the workaround: https://faun.pub/how-to-install-simultaneously-docker-and-podman-on-rhel-8-centos-8-cb67412f321e
+    - RUN rpm --install --nodeps --replacefiles --excludepath=/usr/bin/runc https://download.docker.com/linux/centos/8/x86_64/stable/Packages/containerd.io-1.5.10-3.1.el8.x86_64.rpm
+    - RUN dnf --assumeyes --enablerepo=docker-ce-stable install docker-ce
+    - RUN molecule --version
+    - RUN molecule drivers
+    - RUN ansible-lint --version
+    - RUN docker --version
+    - RUN podman --version
+    - RUN git --version


### PR DESCRIPTION
In #22 and #23 the podman and docker molecule drivers were added, but the respective binaries are still missing.

This commit adds the necessary dependencies to the execution enviroments bindep.txt.

This commit also adds some CLI commands to check we do not remove them inadvertently and output some helpful version information at build time.