### PR TITLE
Add requirements.in file for dependabot

### DIFF
--- a/_build/requirements.in
+++ b/_build/requirements.in
@@ -1,0 +1,8 @@
+# Used to help dependabot bump the lock file
+ansible-lint>=6.0.2
+molecule>=3.6.1
+molecule-containers>=1.0.2
+molecule-docker>=1.1.0
+molecule-openstack>=0.3
+molecule-podman>=1.1.0
+yamllint>=1.26.3

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
     {env:ANSIBLE_BUILDER_POST_ARGS:}
   # safety measure to keep container image under control
   # https://github.com/wemake-services/docker-image-size-limit/issues/223
-  docker: disl {env:ANSIBLE_BUILDER_TARGET_CONTAINER_NAME}:{env:ANSIBLE_BUILDER_TARGET_CONTAINER_TAG} 2200MiB
+  docker: disl {env:ANSIBLE_BUILDER_TARGET_CONTAINER_NAME}:{env:ANSIBLE_BUILDER_TARGET_CONTAINER_TAG} 2300MiB
 deps =
   ansible-builder
   docker-image-size-limit


### PR DESCRIPTION
We also had to increase the size check because changes in rpms increase the image size above our self imposed limit.