### PR TITLE
Remove molecule-docker plugin from creator-ee

### DIFF
--- a/_build/requirements.in
+++ b/_build/requirements.in
@@ -1,8 +1,8 @@
 # Used to help dependabot bump the lock file
 ansible-lint>=6.0.2
 molecule>=3.6.1
-molecule-containers>=1.0.2
-molecule-docker>=1.1.0
+# molecule-containers>=1.0.2 # removed due to molecule-docker being removed
+# molecule-docker>=1.1.0 # removed due to requiring docker-compose<2.0.0
 molecule-openstack>=0.3
 molecule-podman>=2.0.0
 yamllint>=1.26.3

--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -1,7 +1,5 @@
 ansible-lint==6.0.2
 molecule==3.6.1
-molecule-containers==1.0.2
-molecule-docker==1.1.0
 molecule-openstack==0.3
 molecule-podman==2.0.0
 yamllint==1.26.3


### PR DESCRIPTION
This change is needed because community.docker collections has
a requirements on python package docker-compose<2.0 and that is
causing other conflicts with our dependencies. As new docker-compose
versions are no longer on pypi, the only workaround would for the
collection to make that dependency soft.

This will not be added back unless that conflicts are addressed.

That was blocking ansible-lint version upgrade inside the container, as seen on https://github.com/ansible/creator-ee/pull/62