### PR TITLE
Remove community.docker and docker from creator-ee

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -28,24 +28,11 @@ COPY --from=galaxy /usr/share/ansible /usr/share/ansible
 COPY --from=builder /output/ /output/
 RUN /output/install-from-bindep && rm -rf /output/wheels
 RUN alternatives --set python /usr/bin/python3
-RUN set -ex \
-  && dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo \
-  && dnf config-manager --set-disabled docker-ce-stable \
-#  This is a workaround due to a conflict between the packaged version of runc in the containerd.io package from Docker and the CentOS 8 Stream native
-#  version packaged for Podman and Skopeo. This can be changed once https://github.com/docker/containerd-packaging/pull/231 is merged and available
-#  upstream via the Docker repository. Cudos for the workaround: https://faun.pub/how-to-install-simultaneously-docker-and-podman-on-rhel-8-centos-8-cb67412f321e
-  && rpm --install --nodeps --replacefiles --excludepath=/usr/bin/runc https://download.docker.com/linux/centos/8/x86_64/stable/Packages/containerd.io-1.5.10-3.1.el8.x86_64.rpm \
-  && dnf --assumeyes --enablerepo=docker-ce-stable install docker-ce \
-  && dnf clean all \
-  && rm -rf /var/cache/{dnf,yum} \
-  && rm -rf /var/lib/dnf/history.* \
-  && rm -rf /var/log/*
 # add some helpful CLI commands to check we do not remove them inadvertently and output some helpful version information at build time.
 RUN set -ex \
   && molecule --version \
   && molecule drivers \
   && ansible-lint --version \
-  && docker --version \
   && podman --version \
   && python --version \
   && git --version

--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -5,7 +5,8 @@ collections:
   - name: ansible.windows
   - name: awx.awx
   - name: azure.azcollection
-  - name: community.docker
+  # Removed due to its dependency on unmaintained docker-compose python package
+  # - name: community.docker
   - name: community.vmware
   - name: containers.podman
   - name: google.cloud

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -9,25 +9,11 @@ additional_build_steps:
   append:
     - RUN alternatives --set python /usr/bin/python3
     - |-
-      RUN set -ex \
-        && dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo \
-        && dnf config-manager --set-disabled docker-ce-stable \
-      #  This is a workaround due to a conflict between the packaged version of runc in the containerd.io package from Docker and the CentOS 8 Stream native
-      #  version packaged for Podman and Skopeo. This can be changed once https://github.com/docker/containerd-packaging/pull/231 is merged and available
-      #  upstream via the Docker repository. Cudos for the workaround: https://faun.pub/how-to-install-simultaneously-docker-and-podman-on-rhel-8-centos-8-cb67412f321e
-        && rpm --install --nodeps --replacefiles --excludepath=/usr/bin/runc https://download.docker.com/linux/centos/8/x86_64/stable/Packages/containerd.io-1.5.10-3.1.el8.x86_64.rpm \
-        && dnf --assumeyes --enablerepo=docker-ce-stable install docker-ce \
-        && dnf clean all \
-        && rm -rf /var/cache/{dnf,yum} \
-        && rm -rf /var/lib/dnf/history.* \
-        && rm -rf /var/log/*
-    - |-
       # add some helpful CLI commands to check we do not remove them inadvertently and output some helpful version information at build time.
       RUN set -ex \
         && molecule --version \
         && molecule drivers \
         && ansible-lint --version \
-        && docker --version \
         && podman --version \
         && python --version \
         && git --version

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
     {env:ANSIBLE_BUILDER_POST_ARGS:}
   # safety measure to keep container image under control
   # https://github.com/wemake-services/docker-image-size-limit/issues/223
-  docker: disl {env:ANSIBLE_BUILDER_TARGET_CONTAINER_NAME}:{env:ANSIBLE_BUILDER_TARGET_CONTAINER_TAG} 2300MiB
+  docker: disl {env:ANSIBLE_BUILDER_TARGET_CONTAINER_NAME}:{env:ANSIBLE_BUILDER_TARGET_CONTAINER_TAG} 1700MiB
 deps =
   ansible-builder
   docker-image-size-limit


### PR DESCRIPTION
That change finishes #65 and removes any docker use from our container. The root cause of this change being the conflicts caused by unmaintained community.docker collection which has a hard dependency on python docker-compose module, which is EOL (being replace by go implementation).

If the maintenance situation does change in the future, we might bring it back in but we cannot block other changes due to conflicts caused by it.

References:

* https://github.com/docker/compose/blob/master/setup.py#L28-L37 
* https://github.com/ansible-collections/community.docker/pull/360
* https://pypi.org/project/docker-compose/