### PR TITLE
Specify paramiko 2.11.0

### DIFF
--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -28,6 +28,7 @@ molecule==4.0.1
 molecule-podman==2.0.3
 mypy-extensions==0.4.3
 packaging==21.3
+paramiko==2.11.0
 pathspec==0.10.1
 platformdirs==2.5.2
 pluggy==1.0.0


### PR DESCRIPTION
Fixes #140 

The current version is 2.10.4 which throws an error with cryptography > 37