### PR TITLE
Temporary empty container

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ setenv =
   docker: CONTAINER_RUNTIME=docker
   podman: PODMAN_OPTS="--jobs=4"
   ANSIBLE_BUILDER_POST_ARGS = --container-runtime={env:CONTAINER_RUNTIME:podman}
-  TARGET_CONTAINER_NAME = {env:TARGET_CONTAINER_NAME:quay.io/ansible/creator-ee}
+  TARGET_CONTAINER_NAME = {env:TARGET_CONTAINER_NAME:creator-ee}
   TARGET_CONTAINER_TAG = {env:TARGET_CONTAINER_TAG:x}
 
 [testenv:lint]


### PR DESCRIPTION
Temporary disable most steps inside container, while we rework our
build pipelines to work with multi-arch containers as each run takes
more than 1.5h.
