### PR TITLE
Set workdir in containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -28,4 +28,9 @@ RUN set -ex \
 
 ADD _build/entrypoint.sh /bin/entrypoint
 RUN chmod +x /bin/entrypoint
+
+# Carried forward from the runner EE build and used by navigator to determine if a container is an EE
+# https://github.com/ansible/ansible-builder/issues/424
+WORKDIR /runner
+
 ENTRYPOINT ["entrypoint"]


### PR DESCRIPTION
This is currently used to determine if a container is an EE.

Related: https://github.com/ansible/ansible-navigator/issues/454
Related: https://github.com/ansible/ansible-builder/issues/424