### PR TITLE
Add an EE label

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,6 +9,8 @@ LABEL org.opencontainers.image.authors "Ansible DevTools"
 LABEL org.opencontainers.image.vendor "Red Hat"
 LABEL org.opencontainers.image.licenses "GPL-3.0"
 
+LABEL ansible-execution-environment=true
+
 USER root
 
 COPY _build/requirements.in /root/requirements.in
@@ -25,10 +27,6 @@ RUN set -ex \
 && python3 --version \
 && git --version \
 && uname -a
-
-# mimic builder / used by navigator
-# https://github.com/ansible/ansible-navigator/pull/1317
-LABEL ansible-execution-environment=true
 
 ADD _build/entrypoint.sh /bin/entrypoint
 RUN chmod +x /bin/entrypoint

--- a/Containerfile
+++ b/Containerfile
@@ -26,6 +26,10 @@ RUN set -ex \
 && git --version \
 && uname -a
 
+# mimic builder / used by navigator
+# https://github.com/ansible/ansible-navigator/pull/1317
+LABEL ansible-execution-environment=true
+
 ADD _build/entrypoint.sh /bin/entrypoint
 RUN chmod +x /bin/entrypoint
 ENTRYPOINT ["entrypoint"]


### PR DESCRIPTION
Add a label indicating this is an EE.

This will mimic future builder behaviour.

Also allows navigator to recognize this as an execution environment: https://github.com/ansible/ansible-navigator/pull/1317