### PR TITLE
Added non-pure python packages to unsafe list

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,19 @@ repos:
     hooks:
       - id: pip-compile
         name: pip-compile
-        entry: pip-compile --upgrade --pre --no-annotate --output-file=_build/requirements.txt -r _build/requirements.in --strip-extras --no-header
+        entry: >
+          pip-compile
+          --upgrade
+          --pre
+          --no-annotate
+          --output-file=_build/requirements.txt
+          -r _build/requirements.in
+          --strip-extras
+          --no-header
+          --unsafe-package cryptography
+          --unsafe-package setuptools
+          --unsafe-package ruamel-yaml-clib
+        # ^ all not-pure python packages should be added as unsafe
         language: python
         additional_dependencies:
           - pip-tools>=6.9.0

--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -15,7 +15,6 @@ click==8.1.3
 click-help-colors==0.9.1
 commonmark==0.9.1
 cookiecutter==2.1.1
-cryptography==38.0.2
 distro==1.8.0
 enrich==1.2.7
 filelock==3.8.0
@@ -55,4 +54,5 @@ wcmatch==8.4.1
 yamllint==1.28.0
 
 # The following packages are considered to be unsafe in a requirements file:
+# cryptography
 # setuptools


### PR DESCRIPTION
This should prevent pip from trying to install binary wheels.
