### PR TITLE
Install collections from local

### DIFF
--- a/.github/workflows/task.yml
+++ b/.github/workflows/task.yml
@@ -46,6 +46,14 @@ jobs:
           python-version: "3.10" # 3.10 is default on ubuntu-22.04
           cache: "pip"
 
+      - name: Set cache for galaxy
+        uses: actions/cache@v3
+        if: "contains(matrix.command, 'build')"
+        with:
+          path: |
+            collections
+          key: galaxy-${{ hashFiles('_build/requirements.yml') }}
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .tox
 .task
 out
+collections

--- a/Containerfile
+++ b/Containerfile
@@ -22,8 +22,6 @@ COPY _build/shells /etc/shells
 RUN \
 pip3 install -r requirements.in -c requirements.txt && \
 mkdir -p ~/.ansible/roles && \
-mkdir -p ~/.ansible/collections/ansible_collections && \
-ansible-galaxy collection install -r requirements.yml && \
 rm -rf $(pip3 cache dir)
 
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
@@ -44,9 +42,11 @@ RUN for dir in \
       /etc/passwd \
       /etc/group ; \
     do touch $file ; chmod g+rw $file ; chgrp root $file ; done
+COPY collections/ /usr/share/ansible/collections
 
 # add some helpful CLI commands to check we do not remove them inadvertently and output some helpful version information at build time.
 RUN set -ex \
+&& ansible --version \
 && ansible-lint --version \
 && molecule --version \
 && molecule drivers \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,6 +64,7 @@ tasks:
     deps:
       - setup
     cmds:
+      - ansible-galaxy collection install -r _build/requirements.yml -p collections
       - podman manifest exists {{.CNT_NAME_TAG}} && podman manifest rm {{.CNT_NAME_TAG}} || true
       - podman image exists {{.CNT_NAME_TAG}} && podman image rm {{.CNT_NAME_TAG}} || true
       - podman buildx build ${EXTRA_OPTS:-} --load {{.CNT_ROOT}} --manifest {{.CNT_NAME_TAG}}

--- a/_build/test-setup.sh
+++ b/_build/test-setup.sh
@@ -51,7 +51,7 @@ if [[ -f "/usr/bin/apt-get" ]]; then
     INSTALL=0
     # qemu-user-static is required by podman on arm64
     # python3-dev is needed for headers as some packages might need to compile
-    DEBS=(curl git python3-pip qemu-user-static jq gh)
+    DEBS=(curl git python3-pip python3-venv qemu-user-static jq gh)
     for DEB in "${DEBS[@]}"; do
         [[ "$(dpkg-query --show --showformat='${db:Status-Status}\n' \
             "${DEB}" || true)" != 'installed' ]] && INSTALL=1
@@ -129,7 +129,7 @@ python3 -c "import os, stat, sys; sys.exit(os.stat('.').st_mode & stat.S_IWOTH)"
 }
 
 python3 -m pre_commit --version >/dev/null 2>&1 || {
-    python3 -m pip install -q pre-commit
+    python3 -m pip install -q pre-commit ansible-core
 }
 
 # Detect podman and ensure that it is usable (unless SKIP_PODMAN)


### PR DESCRIPTION
This should greatly increase the multi-arch container building speed by just installing collections from the host and avoiding running the installation from within the containers.
