### PR TITLE
Specifically install python

### DIFF
--- a/base/Containerfile
+++ b/base/Containerfile
@@ -19,4 +19,14 @@ microdnf install -y \
 dumb-init \
 git \
 podman \
+python3 \
+python3-bcrypt \
+python3-cffi \
+python3-cryptography \
+python3-pip \
+python3-pynacl \
+python3-pyrsistent \
+python3-pyyaml \
+python3-ruamel-yaml \
+python3-wheel \
 && microdnf clean all

--- a/base/Containerfile
+++ b/base/Containerfile
@@ -19,13 +19,4 @@ microdnf install -y \
 dumb-init \
 git \
 podman \
-python3-bcrypt \
-python3-cffi \
-python3-cryptography \
-python3-pip \
-python3-pynacl \
-python3-pyrsistent \
-python3-pyyaml \
-python3-ruamel-yaml \
-python3-wheel \
 && microdnf clean all


### PR DESCRIPTION
With the switch to fedora-minimal, python3 is no longer included in the base image for the creator-base.

Rather than pull it in as a dep for one of the python microdnf packages, explicitly install it.

The outcome is the same, but the installation of python3 is now explicit.

This will make it easier for future developers to test or modify the version of python being installed because it is listed as a first-class package.