### PR TITLE
Add colored bash prompt

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,12 @@
 # Overly simplified single stage build process: we take all binary dependencies
 # using dnf and use pip to install the rest.
+
+# this arg must be declared before FROM
 ARG EE_BASE_IMAGE=quay.io/ansible/creator-base:latest
 FROM $EE_BASE_IMAGE
+# this arg must be declared after FROM
+ARG CONTAINER_NAME
+ENV CONTAINER_NAME $CONTAINER_NAME
 
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
 LABEL org.opencontainers.image.source https://github.com/ansible/creator-ee
@@ -18,6 +23,7 @@ COPY _build/requirements.txt requirements.txt
 COPY _build/requirements.yml requirements.yml
 COPY _build/devtools-publish /usr/local/bin/devtools-publish
 COPY _build/shells /etc/shells
+COPY _build/.bashrc /home/runner/.bashrc
 RUN \
 pip3 install --compile --only-binary :all: \
 -r requirements.txt && \
@@ -25,7 +31,9 @@ mkdir -p ~/.ansible/roles /usr/share/ansible/roles /etc/ansible/roles && \
 rm -rf $(pip3 cache dir) && \
 # Avoid "fatal: detected dubious ownership in repository at" with newer git versions
 # See https://github.com/actions/runner-images/issues/6775
-git config --global --add safe.directory /
+git config --global --add safe.directory / && \
+  # Create bashrc file with colored prompt using container name
+printf "export CONTAINER_NAME=$CONTAINER_NAME\n" >> /home/runner/.bashrc
 
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,7 +73,7 @@ tasks:
       - ansible-galaxy collection install -r _build/requirements.yml -p collections
       - podman manifest exists {{.CNT_NAME_TAG}} && podman manifest rm {{.CNT_NAME_TAG}} || true
       - podman image exists {{.CNT_NAME_TAG}} && podman image rm {{.CNT_NAME_TAG}} || true
-      - podman buildx build ${EXTRA_OPTS:-} --load {{.CNT_ROOT}} --manifest {{.CNT_NAME_TAG}}
+      - podman buildx build ${EXTRA_OPTS:-} --build-arg=CONTAINER_NAME={{.CNT_NAME_TAG}} --load {{.CNT_ROOT}} --manifest {{.CNT_NAME_TAG}}
       # running manifest exists is mandatory as this fails if no manifest is
       # created locally. If this is skipped the inspect might pull the last
       # published manifest instead of using the local one.

--- a/_build/.bashrc
+++ b/_build/.bashrc
@@ -1,0 +1,11 @@
+#!/bin/bash
+PROMPT_COMMAND=__prompt_command
+
+__prompt_command() {
+    local RC="$?"
+    RC_MSG=""
+    if [ "$RC" != 0 ]; then
+        RC_MSG="\[$(tput sgr0)\]\[\033[38;5;9m\]$RC\[$(tput sgr0)\]"
+    fi
+    PS1="\[\033[38;5;56m\]\u\[$(tput sgr0)\]\[\033[38;5;8m\]@\[$(tput sgr0)\]\[\033[38;5;130m\]${CONTAINER_NAME}\[$(tput sgr0)\]: \[$(tput sgr0)\]\[\033[38;5;25m\]\w\[$(tput sgr0)\] \[$(tput sgr0)\]\[\033[38;5;28m\]\$(git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/')\[$(tput sgr0)\]$RC_MSG\n\\$ \[$(tput sgr0)\]"
+}


### PR DESCRIPTION
This adds a custom bash prompt for the container that consists of two lines
- (1st line) user, container tag name as hostname, current directory
- if the previous command failed a red exit code number is appended to 1st line
- 2nd line contains just the prompt, making easy to follow on screen by making less likely that that command would wrap on multiple lines. 

![ss](https://sbarnea.com/ss/Screen-Shot-2023-01-01-20-58-42.05.png)