### PR TITLE
Keep rpm db

### DIFF
--- a/base/Containerfile
+++ b/base/Containerfile
@@ -31,6 +31,4 @@ python3-pyrsistent \
 python3-pyyaml \
 python3-ruamel-yaml \
 python3-wheel \
-&& microdnf clean all \
-# See https://lwn.net/Articles/881107/
-&& rm -rf /usr/lib/sysimage/rpm
+&& microdnf clean all


### PR DESCRIPTION
ansible-navigator run `rpm -qa` to catalog the installed system packages.

We'll keep the rpm db.

https://github.com/ansible/ansible-navigator/blob/e915bcf08aaec4cbbd59c76587c4d53d3346b16a/share/ansible_navigator/utils/image_introspect.py#L347