### PR TITLE
Install git-core instead of git on base image

### DIFF
--- a/base/Containerfile
+++ b/base/Containerfile
@@ -17,7 +17,7 @@ microdnf update -y && \
 microdnf -y upgrade && \
 microdnf install -y \
 dumb-init \
-git \
+git-core \
 podman \
 python3 \
 python3-bcrypt \


### PR DESCRIPTION
As we do not need the full git, it is better to only preinstall
git-core on base image.
