### PR TITLE
Add 'ncurses' Package To Provide 'tput'

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -25,6 +25,8 @@ COPY _build/devtools-publish /usr/local/bin/devtools-publish
 COPY _build/shells /etc/shells
 COPY _build/.bashrc /home/runner/.bashrc
 RUN \
+microdnf install --assumeyes ncurses && \
+microdnf clean all && \
 pip3 install --progress-bar=off --compile --only-binary :all: \
 -r requirements.txt && \
 mkdir -p ~/.ansible/roles /usr/share/ansible/roles /etc/ansible/roles && \


### PR DESCRIPTION
* This was needed to get 'bash' inside the container to work correctly on a Fedora 37 with the new changes to add colors to the prompt

Resolves #293 