### PR TITLE
Preinstall cython to avoid pyyaml installation errors

### DIFF
--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -1,3 +1,7 @@
+# prepare:
+# see: https://github.com/yaml/pyyaml/issues/601
+cython>=3.0.5; python_version >= "3.12"
+# ordered:
 ansible-pylibssh==1.1.0
 ansible-runner==2.3.4
 ansible-lint[lock]==6.21.1

--- a/_build/test-setup.sh
+++ b/_build/test-setup.sh
@@ -51,7 +51,8 @@ if [[ -f "/usr/bin/apt-get" ]]; then
     INSTALL=0
     # qemu-user-static is required by podman on arm64
     # python3-dev is needed for headers as some packages might need to compile
-    DEBS=(curl git python3-pip python3-venv qemu-user-static jq gh)
+    # cython3 is needed to headers to compile pyyaml 6.0, see https://github.com/yaml/pyyaml/issues/601
+    DEBS=(curl git python3-pip python3-venv cython3 qemu-user-static jq gh)
     for DEB in "${DEBS[@]}"; do
         [[ "$(dpkg-query --show --showformat='${db:Status-Status}\n' \
             "${DEB}" || true)" != 'installed' ]] && INSTALL=1


### PR DESCRIPTION
Related: https://github.com/yaml/pyyaml/issues/601

When released, this should also fix the setup phase of testing in extension, which happens use py312 with requirements from this repository.
