### PR TITLE
Add Power and Z Support to the creator-ee image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,7 +26,7 @@ COPY _build/devtools-publish /usr/local/bin/devtools-publish
 COPY _build/shells /etc/shells
 COPY _build/.bashrc /home/runner/.bashrc
 RUN \
-microdnf install --assumeyes ncurses && \
+microdnf install --assumeyes ncurses rustc cargo openssl openssl-devel && \
 microdnf clean all && \
 pip3 install --progress-bar=off \
 -r requirements.txt && \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,7 +45,7 @@ tasks:
       - podman container prune -f
       - podman manifest exists {{.CNT_NAME_TAG}} && podman manifest rm {{.CNT_NAME_TAG}} || true
       - podman image exists {{.CNT_NAME_TAG}} && podman image rm -f {{.CNT_NAME_TAG}} || true
-      - podman buildx build ${EXTRA_OPTS:---platform=linux/amd64,linux/arm64} --load {{.CNT_ROOT}} --manifest localhost/{{.CNT_NAME_TAG}}
+      - podman buildx build ${EXTRA_OPTS:---platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x} --load {{.CNT_ROOT}} --manifest localhost/{{.CNT_NAME_TAG}}
       # running manifest exists is mandatory as this fails if no manifest is
       # created locally. If this is skipped the inspect might pull the last
       # published manifest instead of using the local one.
@@ -93,7 +93,7 @@ tasks:
       - podman container prune -f
       - podman manifest exists {{.CNT_NAME_TAG}} && podman manifest rm {{.CNT_NAME_TAG}} || true
       - podman image exists {{.CNT_NAME_TAG}} && podman image rm -f {{.CNT_NAME_TAG}} || true
-      - podman buildx build ${EXTRA_OPTS:---platform=linux/amd64,linux/arm64} --build-arg=CONTAINER_NAME={{.CNT_NAME_TAG}} --load {{.CNT_ROOT}} --manifest {{.CNT_NAME_TAG}}
+      - podman buildx build ${EXTRA_OPTS:---platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x} --build-arg=CONTAINER_NAME={{.CNT_NAME_TAG}} --load {{.CNT_ROOT}} --manifest {{.CNT_NAME_TAG}}
       # running manifest exists is mandatory as this fails if no manifest is
       # created locally. If this is skipped the inspect might pull the last
       # published manifest instead of using the local one.

--- a/_build/test-setup.sh
+++ b/_build/test-setup.sh
@@ -151,6 +151,8 @@ fi
 # verify podman ability to execute multi-arch commands:
 podman run --arch=arm64 -qit bash arch
 podman run --arch=amd64 -qit bash arch
+podman run --arch=ppc64le -qit bash arch
+podman run --arch=s390x -qit bash arch
 
 # Create a build manifest so we can compare between builds and machines, this
 # also has the role of ensuring that the required executables are present.


### PR DESCRIPTION
Add multi-arch support to the creator-ee image.
Added some P/Z specific dependencies to the Containerfile
Added ppc64le and s390x to the `--platform` tag for the `podman buildx` command in Taskfile.yml file.
Related to Issue #399 